### PR TITLE
Header field names are case insensitive

### DIFF
--- a/background-script.js
+++ b/background-script.js
@@ -154,7 +154,7 @@ function getHeaders(event) {
 
 function findHeader(headers, name) {
 	for ( let header of headers ) {
-		if ( header.name == name )
+		if ( header.name.toLowerCase() == name.toLowerCase() )
 			return header.value;
 	}
 	return null;


### PR DESCRIPTION
Please, see https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

Some servers are building "content-type" header as "Content-Type", and because of this the function findHeader is not able to find the appropriate header.
The proposed solution performs a case insensitive comparison.